### PR TITLE
fix breaking of build.sh in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,8 @@
       "version": "3.7"
     }
   },
-  "postCreateCommand": "sudo apt-get update -y && sudo apt-get install -y libmagic-dev libsnappy-dev",
+  // /usr/share/man/man1/ needs to be writable by the current otherwise installation of package slim will fail (wants to create a man link)
+  "postCreateCommand": "sudo apt-get update -y && sudo apt-get install -y libmagic-dev libsnappy-dev && sudo chmod a+w /usr/share/man/man1/",
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
   ]

--- a/nl_processor/requirements-dev.txt
+++ b/nl_processor/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest>=6.2.5
 markdown2
-# slim (installation will show a permission error, but does work nevertheless - man link is not needed)
+# slim (installation wants to create a man link - so /usr/share/man/man1/ needs to be writable by the current user)
 splunk-packaging-toolkit==1.0.1
 semantic_version==2.6.0
 splunk-appinspect


### PR DESCRIPTION
slim installation will break the install script because of a permission issue

does not work in dev container as described in the requirements.txt since several packages won't be installed after
the permission issue

see log:
...
      error: [Errno 13] Permission denied: 'build/bdist.linux-x86_64/wheel/slim/man/man1/slim-describe.1' -> '/usr/share/man/man1/slim-describe.1'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for splunk-packaging-toolkit
  Building wheel for splunk-appinspect (pyproject.toml) ... done
  Created wheel for splunk-appinspect: filename=splunk_appinspect-2.38.0-py3-none-any.whl size=1345525 sha256=e47d7da1c08156f2bfb9512ef08c0ea9adc9cd5f59da37c973efaa39a1dc9591
  Stored in directory: /home/vscode/.cache/pip/wheels/63/5e/9a/1b72b2a4137e6796c24e87cd0f1c7d1aa8c17e0bda4f77943a
  Building wheel for future (pyproject.toml) ... done
  Created wheel for future: filename=future-0.18.3-py3-none-any.whl size=492024 sha256=d73a6e9b505bc25b8e0df051b43bca3bd7e746c756c13dc46eea62c98aa465e7
  Stored in directory: /home/vscode/.cache/pip/wheels/fa/cd/1f/c6b7b50b564983bf3011e8fc75d06047ddc50c07f6e3660b00
  Building wheel for futures-then (pyproject.toml) ... done
  Created wheel for futures-then: filename=futures_then-0.1.1-py3-none-any.whl size=3630 sha256=df47ef1db33f6b82817aec45ab1e905dd9a7455c2c34a04fdb773b1db13897d2
  Stored in directory: /home/vscode/.cache/pip/wheels/2b/db/ba/27c0482ffa84fe6eb5ea1c74be3fa883db132aa3fd9175762b
  Building wheel for langdetect (pyproject.toml) ... done
  Created wheel for langdetect: filename=langdetect-1.0.9-py3-none-any.whl size=993224 sha256=554b8a7d3658dba40bd0f04034ebdbe26c9ffce688f0e92818e29c7af16303f5
  Stored in directory: /home/vscode/.cache/pip/wheels/c5/96/8a/f90c59ed25d75e50a8c10a1b1c2d4c402e4dacfa87f3aff36a
  Building wheel for painter (pyproject.toml) ... done
  Created wheel for painter: filename=painter-0.3.1-py3-none-any.whl size=7059 sha256=d889aa266c327cc7ba987b91d35cf0b4dd6cf9ce7d5d1a141607240769efe04c
  Stored in directory: /home/vscode/.cache/pip/wheels/15/d5/0e/8ef87b4ed7720ca6943efccfba1e03de9fd7e24b14af08a2cc
Successfully built splunk-appinspect future futures-then langdetect painter
Failed to build splunk-packaging-toolkit
ERROR: Could not build wheels for splunk-packaging-toolkit, which is required to install pyproject.toml-based projects
/usr/local/python/current/bin/python: No module named markdown2
/usr/local/python/current/bin/python: No module named slim
build.sh: line 24: splunk-appinspect: command not found