### PR TITLE
Azure support

### DIFF
--- a/nl_processor/README
+++ b/nl_processor/README
@@ -35,6 +35,14 @@ If you want to add just one inference for all events, you can specify the text u
 If you want to limit the amount of API calls, you can specify a maximum number of calls with the parameter `maxcalls`. The default value is `100`. To disable the limit, set `maxcalls=0`.
 If you want to continue on errors, you can specify the parameter `continue_on_errors=true`.
 
+### OpenAI hosted on Azure
+
+If the OpenAI service on Azure is used, the `resource name` has to be configured additionally to the `API key` in the [setup page](/app/nl_processor/setup). 
+
+Additionally the `deployment_id` has to be specified on each call of the OpenAI command.
+
+For example if the deployment name is 'gpt' then use `openai type=completions deployment_id=gpt input=prompt output=explanation`.
+
 # Examples
 
 Note that some models in Hugging Face are not often used and therefore loaded on-demand. If you're getting a `Model ... is currently loading` error, please try again after half a minute.
@@ -58,6 +66,8 @@ We can use this prompt template to let OpenAI generate an explanation for an err
     | lookup prompts.csv id output prompt
     | eval prompt=replace(replace(prompt,"{COMPONENT}",component),"{ERROR}",error)
     | openai type=completions input=prompt output=explanation
+
+If using Azure, make sure to add the parameter `deployment_id` to the openai command.
 
 ## Named Entity Recognition
 
@@ -88,6 +98,8 @@ The following example is generating an [embedding](https://en.wikipedia.org/wiki
     | makeresults
     | eval input="Covid cases are increasing fast!"
     | openai input=input output=embedding
+
+If using Azure, make sure to add the parameter `deployment_id` to the openai command.
 
 Embeddings can be used for tasks such as semantic search, clustering and text classification.
 
@@ -137,6 +149,8 @@ Then create a lookup table for the embeddings of the two classification labels (
     | eval label=case(id==1, "positive", id==2, "negative")
     | openai input="label" output=embedding
     | outputlookup labels.csv
+
+If using Azure, make sure to add the parameter `deployment_id` to the openai command.
 
 Finally, calculate the cosine similarity between review embeddings and label embeddings, predict the label, and aggregate the results by airline:
 

--- a/nl_processor/appserver/static/setup.js
+++ b/nl_processor/appserver/static/setup.js
@@ -6,6 +6,9 @@ require(["jquery", "splunkjs/splunk", "splunkjs/ready!"], function (
 ) {
   const apiTokenInput = $("splunk-text-input[name='hf_api_token']");
   const openAIapiKeyInput = $("splunk-text-input[name='openai_api_key']");
+  const azureResourceNameInput = $(
+    "splunk-text-input[name='azure_resource_name']"
+  );
 
   const http = new splunkjs.SplunkWebHttp();
   const service = new splunkjs.Service(http, {
@@ -13,14 +16,15 @@ require(["jquery", "splunkjs/splunk", "splunkjs/ready!"], function (
     app: appName,
     sharing: "app",
   });
+  const endpoint = new splunkjs.Service.Endpoint(service, "configure");
 
   const configure = async function () {
     return new Promise(function (resolve, reject) {
       const options = {
         hf_api_token: apiTokenInput.attr("value") || "",
         openai_api_key: openAIapiKeyInput.attr("value") || "",
+        azure_resource_name: azureResourceNameInput.attr("value") || "",
       };
-      const endpoint = new splunkjs.Service.Endpoint(service, "configure");
       endpoint.post("", options, function (err, response) {
         if (err) {
           console.log(err);
@@ -43,4 +47,17 @@ require(["jquery", "splunkjs/splunk", "splunkjs/ready!"], function (
   };
 
   $("#setupButton").click(performSetup);
+
+
+  endpoint
+    .get()
+    .then((response) => {
+      const jsonData = JSON.parse(response);
+      $("#azure_resource_name").attr("value", jsonData["azure_resource_name"]);
+      $("#hf_api_token").attr("value", jsonData["hf_api_token"]);
+      $("#openai_api_key").attr("value", jsonData["openai_api_key"]);
+    })
+    .catch((error) => {
+      alert("Error reading configuration: " + error.error);
+    });
 });

--- a/nl_processor/bin/handlers/configure.py
+++ b/nl_processor/bin/handlers/configure.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from splunklib import client
 from splunk.persistconn.application import PersistentServerConnectionApplication
-from passwords import encode_password
+from passwords import encode_password, decode_password
 
 
 def flatten_query_params(params):
@@ -17,6 +17,10 @@ def flatten_query_params(params):
     return flattened
 
 
+def is_unchanged_password(text):
+    return all(char == "*" for char in text)
+
+
 class ConfigureHandler(PersistentServerConnectionApplication):
     def __init__(self, _command_line, _command_arg):
         PersistentServerConnectionApplication.__init__(self)
@@ -24,22 +28,15 @@ class ConfigureHandler(PersistentServerConnectionApplication):
     def handle(self, in_string):
         try:
             request = json.loads(in_string)
-            payload = flatten_query_params(request["form"])
-            hf_api_token = payload["hf_api_token"]
-            openai_api_key = payload["openai_api_key"]
-
             service = client.Service(
                 token=request["system_authtoken"], sharing="app", app="nl_processor"
             )
-            encode_password(service, "hf_api_token", hf_api_token)
-            encode_password(service, "openai_api_key", openai_api_key)
 
-            return {"payload": {"success": "true"}, "status": 200}
-        except (KeyError, ValueError) as e:
-            return {
-                "payload": {"success": "false", "result": f"Error parsing JSON: {e}"},
-                "status": 400,
-            }
+            if request["method"] == "POST":
+                payload = flatten_query_params(request["form"])
+                return self.handle_post(service, payload)
+            else:
+                return self.handle_get(service)
         except Exception as ex:
             import traceback
 
@@ -50,4 +47,46 @@ class ConfigureHandler(PersistentServerConnectionApplication):
                     "traceback": traceback.format_exc(),
                 },
                 "status": 500,
+            }
+
+    def handle_get(self, service):
+        conf = service.confs["commands"]
+        stanza = conf["openai"]
+
+        azure_resource_name = (
+            stanza["azure_resource_name"] if "azure_resource_name" in stanza else ""
+        )
+        hf_api_token = "***" if decode_password(service, "hf_api_token") else ""
+        openai_api_key = "***" if decode_password(service, "openai_api_key") else ""
+
+        return {
+            "payload": {
+                "success": "true",
+                "azure_resource_name": azure_resource_name,
+                "hf_api_token": hf_api_token,
+                "openai_api_key": openai_api_key,
+            },
+            "status": 200,
+        }
+
+    def handle_post(self, service, payload):
+        try:
+            hf_api_token = payload["hf_api_token"]
+            openai_api_key = payload["openai_api_key"]
+            azure_resource_name = payload["azure_resource_name"]
+
+            conf = service.confs["commands"]
+            stanza = conf["openai"]
+            stanza.submit({"azure_resource_name": azure_resource_name})
+
+            if not is_unchanged_password(hf_api_token):
+                encode_password(service, "hf_api_token", hf_api_token)
+            if not is_unchanged_password(openai_api_key):
+                encode_password(service, "openai_api_key", openai_api_key)
+
+            return {"payload": {"success": "true"}, "status": 200}
+        except (KeyError, ValueError) as e:
+            return {
+                "payload": {"success": "false", "result": f"Error parsing JSON: {e}"},
+                "status": 400,
             }

--- a/nl_processor/bin/passwords.py
+++ b/nl_processor/bin/passwords.py
@@ -26,8 +26,9 @@ def encode_password(service, field_name, password):
         if storage_password.clear_password != password:
             # password exists and it got changed, update it
             service.storage_passwords.delete(field_name, passwords_realm)
-            storage_password = service.storage_passwords.create(
-                password, field_name, passwords_realm
-            )
+            if password:
+                storage_password = service.storage_passwords.create(
+                    password, field_name, passwords_realm
+                )
     else:
         service.storage_passwords.create(password, field_name, passwords_realm)

--- a/nl_processor/default/data/ui/views/setup.xml
+++ b/nl_processor/default/data/ui/views/setup.xml
@@ -9,7 +9,7 @@
           <p><a href="http://hf.co/settings/tokens" target="_blank">Get your API token</a> from
             Hugging Face and enter it here.</p>
           <splunk-control-group label="API Token" help="The API token retrieved from Hugging Face">
-            <splunk-text-input name="hf_api_token">
+            <splunk-text-input id="hf_api_token" name="hf_api_token">
             </splunk-text-input>
           </splunk-control-group>
         </div>
@@ -19,10 +19,24 @@
       <title>OpenAI Settings</title>
       <html>
         <div class="form-horizontal">
-          <p><a href="https://platform.openai.com/account/api-keys" target="_blank">Get your API
-            token</a> from OpenAI and enter it here.</p>
-          <splunk-control-group label="API Key" help="The API key retrieved from  OpenAI">
-            <splunk-text-input name="openai_api_key">
+          <dl>
+            <dt>To directly use OpenAI</dt>
+            <dd>- <a href="https://platform.openai.com/account/api-keys" target="_blank">Get your
+                API token</a> from OpenAI and enter it as <b>API Key</b>.</dd>
+            <dt>To use the OpenAI service on Azure</dt>
+            <dd>- <a href="https://azure.microsoft.com/en-us/products/ai-services/openai-service"
+                target="_blank">Get your
+                API token</a> from Azure and enter it as <b>API Key</b>.</dd>
+            <dd>- Additionally specify your <b>resource name</b> for azure (https://{resource
+              name}.openai.azure.com/).</dd>
+          </dl>
+          <splunk-control-group label="API Key" help="The API key retrieved from  OpenAI (or Azure)">
+            <splunk-text-input id="openai_api_key" name="openai_api_key">
+            </splunk-text-input>
+          </splunk-control-group>
+          <splunk-control-group label="resource name"
+            help="If running OpenAI on Azure, the name of the azure resource (otherwise empty)">
+            <splunk-text-input id="azure_resource_name" name="azure_resource_name">
             </splunk-text-input>
           </splunk-control-group>
         </div>

--- a/nl_processor/default/web.conf
+++ b/nl_processor/default/web.conf
@@ -1,3 +1,3 @@
 [expose:configure]
 pattern = /configure
-methods = POST
+methods = POST, GET


### PR DESCRIPTION
Add support for azure
- add configuration setting of resource_name for azure deployment
- add mandatory argument 'deployment_id' if openai command is used on azure
 example: "| openai type=completions deployment_id=gpt35t input=prompt output=explanation"
 
The openai command will send a request to openai if the resource_name setting has not been specified.
Otherwise the request will be sent to azure.